### PR TITLE
Allow "clear" command to be used in shell prompt

### DIFF
--- a/shell.php
+++ b/shell.php
@@ -239,7 +239,6 @@ if (isset($_GET["feature"])) {
                 } else if (/^\s*clear\s*$/.test(command)) {
                     // Backend shell TERM environment variable not set. Clear command history from UI but keep in buffer
                     eShellContent.innerHTML = '';
-                    eShellContent.scrollTop = eShellContent.scrollHeight;
                 } else {
                     makeRequest("?feature=shell", {cmd: command, cwd: CWD}, function (response) {
                         if (response.hasOwnProperty('file')) {

--- a/shell.php
+++ b/shell.php
@@ -236,6 +236,10 @@ if (isset($_GET["feature"])) {
                 _insertCommand(command);
                 if (/^\s*upload\s+[^\s]+\s*$/.test(command)) {
                     featureUpload(command.match(/^\s*upload\s+([^\s]+)\s*$/)[1]);
+                } else if (/^\s*clear\s*$/.test(command)) {
+                    // Backend shell TERM environment variable not set. Clear command history from UI but keep in buffer
+                    eShellContent.innerHTML = '';
+                    eShellContent.scrollTop = eShellContent.scrollHeight;
                 } else {
                     makeRequest("?feature=shell", {cmd: command, cwd: CWD}, function (response) {
                         if (response.hasOwnProperty('file')) {


### PR DESCRIPTION
Currently the shell command history and output is populated in the history area. I usually miss the *clear* screen feature. 

This PR will allow us to send "clear" command. Instead of sending it to the backend, we will handle locally.