### PR TITLE
Add optional basic auth

### DIFF
--- a/shell.php
+++ b/shell.php
@@ -3,6 +3,7 @@
 $SHELL_CONFIG = [
     'username' => 'p0wny',
     'hostname' => 'shell',
+    'authpass' => 'p0wny', // change this! leave blank to disable auth
 ];
 
 function expandPath($path) {
@@ -153,6 +154,18 @@ function initShellConfig() {
     $hostname = gethostname();
     if ($hostname !== false) {
         $SHELL_CONFIG['hostname'] = $hostname;
+    }
+}
+
+if ($SHELL_CONFIG['authpass']) {
+    if (
+        !isset($_SERVER['PHP_AUTH_PW']) ||
+        $_SERVER['PHP_AUTH_PW'] !== $SHELL_CONFIG['authpass']
+    ) {
+        header('WWW-Authenticate: Basic realm="p0wny shell"');
+        header('HTTP/1.0 401 Unauthorized');
+        echo 'Unauthorized';
+        exit;
     }
 }
 


### PR DESCRIPTION
You now can set a password in the SHELL_CONFIG variable. A basic auth prompt will ask for the password when opening the page (user name is ignored). When authpass is set to a blank string the feature is disabled again, just like before.

This should give some peace of mind when using this script as it should prevent 3rd parties to access it while you use it.